### PR TITLE
Set correct options when updating chart data.

### DIFF
--- a/resources/assets/js/core/components/ChartVolume.vue
+++ b/resources/assets/js/core/components/ChartVolume.vue
@@ -75,12 +75,13 @@ export default {
         if (!ctx) {
           return;
         }
-          
+
         const data = this._buildChartData(volumeData, interval);
         const options = this._getChartOptions(interval);
 
         if (this.chartInstance) {
           this.chartInstance.config.data = data;
+          this.chartInstance.options = options;
           this.chartInstance.update();
         }
         else {


### PR DESCRIPTION
When re-rendering the chart, we need to set options as well as data to display the tooltip correctly.